### PR TITLE
Make a deprecation warning when calling set_$rel with a list.

### DIFF
--- a/lib/DBIx/Class/Relationship/ManyToMany.pm
+++ b/lib/DBIx/Class/Relationship/ManyToMany.pm
@@ -115,6 +115,10 @@ EOW
         "{$set_meth} needs a list of objects or hashrefs"
       );
       my @to_set = (ref($_[0]) eq 'ARRAY' ? @{ $_[0] } : @_);
+      ref $_[0] eq 'ARRAY' or warn 
+        "Calling $set_meth with a list of objects is deprecated"
+      . " - please use an arrayref instead.";
+      
       # if there is a where clause in the attributes, ensure we only delete
       # rows that are within the where restriction
       if ($rel_attrs && $rel_attrs->{where}) {


### PR DESCRIPTION
Hadn't realised that set_$rel on many-to-many relationship was called with an arrayref, so I thought a warning would be nice in case anyone did it in future.
