### PR TITLE
exception_action's ignorance of exceptions which stringify to empty string 

### DIFF
--- a/lib/DBIx/Class/Storage/BlockRunner.pm
+++ b/lib/DBIx/Class/Storage/BlockRunner.pm
@@ -145,7 +145,7 @@ sub _run {
     my $storage = $weakself->storage;
     my $cur_depth = $storage->transaction_depth;
 
-    if (defined $txn_init_depth and $run_err eq '') {
+    if (defined $txn_init_depth and not $run_err) {
       my $delta_txn = (1 + $txn_init_depth) - $cur_depth;
 
       if ($delta_txn) {
@@ -163,7 +163,7 @@ sub _run {
     }
 
     # something above threw an error (could be the begin, the code or the commit)
-    if ($run_err ne '') {
+    if ($run_err) {
 
       # attempt a rollback if we did begin in the first place
       if ($txn_begin_ok) {

--- a/t/33exception_wrap.t
+++ b/t/33exception_wrap.t
@@ -23,4 +23,17 @@ is_deeply (
   'Exception-arrayref contents preserved',
 );
 
+# Exception class which stringifies to empty string
+{
+    package DBICTest::ExceptionEmptyString;
+    use overload bool => sub { 1 }, '""' => sub { "" }, fallback => 1;
+    sub new { bless {}, shift; }
+}
+
+dies_ok (sub {
+  $schema->txn_do (sub { die DBICTest::ExceptionEmptyString->new });
+}, 'Exception-empty string object thrown');
+
+isa_ok $@, 'DBICTest::ExceptionEmptyString', "Exception-empty string";
+
 done_testing;


### PR DESCRIPTION
I'm not sure about how to find out that exception happened the right way. It seems to me that there is no simple way to check that $@ contains exactly empty string but not something which pretends to be. I am used to check that exception happened by writing "if( $@ ) {...}" ie ckecking for true/false. So my fix proposition may be good for me but not for all cases out there.