### PR TITLE
Clarifying the Cookbook's method-modifer text & example

### DIFF
--- a/lib/DBIx/Class/Manual/Cookbook.pod
+++ b/lib/DBIx/Class/Manual/Cookbook.pod
@@ -1941,8 +1941,8 @@ just looking for this.
 For example, say that you have three columns, C<id>, C<number>, and
 C<squared>.  You would like to make changes to C<number> and have
 C<squared> be automagically set to the value of C<number> squared.
-You can accomplish this by wrapping the C<number> accessor with
-L<Class::Method::Modifiers>:
+You can accomplish this by wrapping the C<number> accessor with the C<around> method modifier, available through either 
+L<Class::Method::Modifiers> or L<Moose|Moose::Manual::MethodModifiers>):
 
   around number => sub {
     my ($orig, $self) = (shift, shift);
@@ -1953,7 +1953,7 @@ L<Class::Method::Modifiers>:
     }
 
     $self->$orig(@_);
-  }
+  };
 
 Note that the hard work is done by the call to C<< $self->$orig >>, which
 redispatches your call to store_column in the superclass(es).


### PR DESCRIPTION
I've added text clarifying that the "around" method modifier is also available through Moose, and fixed what appears to be a syntax error in the example code. 

This way it better agrees with similar information found in DBIC::Manual::FAQ (under "How do I override a run time method")?
