### PR TITLE
fixes a bug with the _dequalify_idents piece that stripped out schema. before a table name

### DIFF
--- a/lib/DBIx/Class/ResultSet.pm
+++ b/lib/DBIx/Class/ResultSet.pm
@@ -1812,6 +1812,7 @@ sub _rs_update_delete {
     $cond = do {
       my $sqla = $rsrc->storage->sql_maker;
       local $sqla->{_dequalify_idents} = 1;
+      local $sqla->{_table_name} = $rsrc->name;
       \[ $sqla->_recurse_where($self->{cond}) ];
     };
   }

--- a/lib/DBIx/Class/SQLMaker.pm
+++ b/lib/DBIx/Class/SQLMaker.pm
@@ -87,7 +87,8 @@ sub __max_int () { 0x7FFFFFFF };
 
 # poor man's de-qualifier
 sub _quote {
-  $_[0]->next::method( ( $_[0]{_dequalify_idents} and ! ref $_[1] )
+  $_[0]->next::method( ( $_[0]{_dequalify_idents} and (! ref $_[1])
+    and $_[1] ne $_[0]{_table_name} )
     ? $_[1] =~ / ([^\.]+) $ /x
     : $_[1]
   );


### PR DESCRIPTION
for certain delete statements the dequalification process would result in the schema. portion of a table name to be stripped out.  This solution simply is to make the dequalifier aware of the table name so if its looking at the table name it will do nothing instead of blindly stripping off everything before a .
