### PR TITLE
noticed Joining and Features were not mentioned in the DocMap

### DIFF
--- a/lib/DBIx/Class/Manual/DocMap.pod
+++ b/lib/DBIx/Class/Manual/DocMap.pod
@@ -10,7 +10,11 @@ DBIx::Class::Manual::DocMap - What documentation do we have?
 
 =item L<DBIx::Class::Manual::Intro> - Introduction to setting up and using DBIx::Class.
 
+=item L<DBIx::Class::Manual::Features> - A boatload of DBIx::Class features with links to respective documentation.
+
 =item L<DBIx::Class::Manual::Example> - Full example Schema.
+
+=item L<DBIx::Class::Manual::Joining> - Joining tables with DBIx::Class.
 
 =item L<DBIx::Class::Manual::SQLHackers> - How to use DBIx::Class if you know SQL (external, available on CPAN)
 


### PR DESCRIPTION
some of the local Manual pages are not mentioned in the DocMap which should be, 
as people will use the DocMap as a stepping point, and may thus overlook them
