### PR TITLE
added timezone warnings

### DIFF
--- a/lib/DBIx/Class/InflateColumn/DateTime.pm
+++ b/lib/DBIx/Class/InflateColumn/DateTime.pm
@@ -160,6 +160,11 @@ sub register_column {
     }
   }
 
+  if ($info->{time_zone}) {
+    carp "Putting 'time_zone', ".
+         "please put 'timezone' Instead of 'time_zone' into the '$column' column definition.";
+  }
+
   # shallow copy to avoid unfounded(?) Devel::Cycle complaints
   my $infcopy = {%$info};
 

--- a/t/inflate/datetime_mysql.t
+++ b/t/inflate/datetime_mysql.t
@@ -18,6 +18,13 @@ plan skip_all => 'Inflation tests need ' . DBIx::Class::Optional::Dependencies->
   DBICTest::Schema->load_classes('EventTZDeprecated');
 }
 
+{
+  local $SIG{__WARN__} = sub {
+    like shift, qr/Putting 'time_zone', please put 'timezone' Instead of 'time_zone' into the 'starts_at' column definition\./;
+  };
+  DBICTest::Schema->load_classes('EventTZWarning');
+}
+
 my $schema = DBICTest->init_schema();
 
 # Test "timezone" parameter

--- a/t/lib/DBICTest/Schema/EventTZWarning.pm
+++ b/t/lib/DBICTest/Schema/EventTZWarning.pm
@@ -1,0 +1,29 @@
+package DBICTest::Schema::EventTZWarning;
+
+use strict;
+use warnings;
+
+use base qw/DBICTest::BaseResult/;
+
+__PACKAGE__->load_components(qw/InflateColumn::DateTime/);
+
+__PACKAGE__->table('event_tz_warning');
+
+__PACKAGE__->add_columns(
+  id => { data_type => 'integer', is_auto_increment => 1 },
+  starts_at => {
+    data_type => 'datetime',
+    time_zone => "America/Chicago",
+    locale    => 'de_DE',
+  },
+);
+
+__PACKAGE__->set_primary_key('id');
+
+sub _datetime_parser {
+  require DateTime::Format::MySQL;
+  DateTime::Format::MySQL->new();
+}
+
+
+1;


### PR DESCRIPTION
"DateTime" uses "time_zone". and "DBIx::Class::InflateColumn::DateTime" uses "timezone". 
This becomes a trap. so I added a warning.

Sorry for the poor English.