### PR TITLE
Fix memleak for long-lived resultsets.

### DIFF
--- a/lib/DBIx/Class/Storage/DBI.pm
+++ b/lib/DBIx/Class/Storage/DBI.pm
@@ -2446,6 +2446,10 @@ sub _select_args {
   # invoked, and that's just bad...
 ###
 
+  # Small hack, remove potential infinity _sql_maker_select_args chain
+  # when call queries on the same resultset many times
+  delete $attrs->{_sqlmaker_select_args};
+
   return ( 'select', @{ $orig_attrs->{_sqlmaker_select_args} = [
     $ident, $select, $where, $attrs, @limit_args
   ]} );

--- a/t/110leaktrace.t
+++ b/t/110leaktrace.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+
+use Test::More;
+use lib qw(t/lib);
+use DBICTest;
+
+BEGIN {
+    eval "use Test::LeakTrace";
+    plan 'skip_all' => 'Test::LeakTrace required for this tests' if $@;
+}
+
+my $schema = DBICTest->init_schema();
+
+plan tests => 1;
+
+my $artist_rs = $schema->resultset('Artist')->search({},{order_by=>'me.artistid'});
+no_leaks_ok {
+    my @artists = $artist_rs->all;
+};


### PR DESCRIPTION
It is a recursive attributes hash chain when call search on the same
resultset many times. It looks like pseudo-leak with long-lived resultsets.

In our application (that long-lived daemon) we use something like this:

``` perl
sub periodic_refresh {
  state $rs = $schema->resultset('ServerBackend')->search({status=>'active'},{order_by=>'me.id',prefetch=>'Server'});
  my @fresh_backends = $rs->all; # now we use this workaround: $rs->search; but it is slower because new resultset created on every iteration
  # other refresh logic
}
```

This patch fix a problem.
I'm just not sure of a good name for the test file. Now it is 110leaktrace.t, but it can be renamed to something more appropriate.
