### PR TITLE
Add deprecation warning for $rs->new instead of new_result

### DIFF
--- a/lib/DBIx/Class/ResultSet.pm
+++ b/lib/DBIx/Class/ResultSet.pm
@@ -239,7 +239,11 @@ creation B<will not work>. See also warning pertaining to L</create>.
 
 sub new {
   my $class = shift;
-  return $class->new_result(@_) if ref $class;
+
+  if (ref $class) {
+    carp_unique 'Calling $rs->new usually indicates a mistake - you either wanted $rs->new_result or $rs->search';
+    return $class->new_result(@_);
+  }
 
   my ($source, $attrs) = @_;
   $source = $source->resolve

--- a/t/resultset/deprecated_new.t
+++ b/t/resultset/deprecated_new.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Warn;
+use lib qw(t/lib);
+use DBICTest;
+
+my $schema = DBICTest->init_schema();
+
+my $cd_rs = $schema->resultset("CD");
+
+warnings_exist( sub {
+  my $cd = $cd_rs->new({});
+}, qr/Calling \$rs->new usually indicates a mistake/,
+'deprecation warning when calling new instead of new_result');
+
+done_testing;


### PR DESCRIPTION
Per discussion with mst and ribasushi today in #dbix-class about calling new_result instead of new for row objects.  The constructor will get hosed when using MooseX::NonMoose, so that is another reason to keep things clear by always calling new_result.
