### PR TITLE
fixed example in the DBIx::Class::Storage::DBI::Replicated synopsis

### DIFF
--- a/lib/DBIx/Class/Storage/DBI/Replicated.pm
+++ b/lib/DBIx/Class/Storage/DBI/Replicated.pm
@@ -37,7 +37,7 @@ also define your arguments, such as which balancer you want and any arguments
 that the Pool object should get.
 
   my $schema = Schema::Class->clone;
-  $schema->storage_type( ['::DBI::Replicated', {balancer=>'::Random'}] );
+  $schema->storage_type(['::DBI::Replicated', { balancer_type => '::Random' }]);
   $schema->connection(...);
 
 Next, you need to add in the Replicants.  Basically this is an array of


### PR DESCRIPTION
The example in the synopsis does not work. It should be
`{ balancer_type => '::Random' }` instead of `{ balancer => '::Random' }`
