### PR TITLE
 DBIx::Class::Schema: add output_files to return names of files made by ...

### DIFF
--- a/lib/DBIx/Class/Schema.pm
+++ b/lib/DBIx/Class/Schema.pm
@@ -1159,6 +1159,27 @@ sub create_ddl_dir {
   $self->storage->create_ddl_dir($self, @_);
 }
 
+=head2 output_files
+
+=over 4
+
+=item Arguments: $file
+
+=item Return Value: $file1, $file2, ...
+
+=back
+
+Returns names of files that were written to by the L</create_ddl_dir> method.
+
+=cut
+
+sub output_files {
+    my $self = shift;
+    my $of = $self->{output_files} ||= [];
+    push @$of, @_ if defined $file;
+    return @$of;
+}
+
 =head2 ddl_filename
 
 =over 4

--- a/lib/DBIx/Class/Storage/DBI.pm
+++ b/lib/DBIx/Class/Storage/DBI.pm
@@ -2888,6 +2888,7 @@ sub create_ddl_dir {
 
     my $file;
     my $filename = $schema->ddl_filename($db, $version, $dir);
+    $schema->output_files($filename);
     if (-e $filename && ($version eq $schema_version )) {
       # if we are dumping the current version, overwrite the DDL
       carp "Overwriting existing DDL file - $filename";


### PR DESCRIPTION
We were looking for a good way to retrieve the file names  of the files that were created by create_ddl_dir() without having to resort to scraping the names using readdir().
