### PR TITLE
removed FOREIGNBUILDARGS, it is unnecessary

### DIFF
--- a/lib/DBIx/Class/ResultSet.pm
+++ b/lib/DBIx/Class/ResultSet.pm
@@ -249,8 +249,6 @@ require an equivalent to MooseX::NonMoose since that's built in to Moo.
 
   sub BUILDARGS { $_[2] }
 
-  sub FOREIGNBUILDARGS { $_[2] }
-
   ...your code...
 
   1;


### PR DESCRIPTION
FOREIGNBUILDARGS is added by MooseX::NonMoose and is built into Moo.
It is designed for munging constructor parameters before sending them to the superclass, whereas BUILDARGS is for munging params in the subclass. It is unnecessary in this case, as Moo(se) ( the subclass ) is the one that needs it's constructor params munged, not DBIx::Class::ResultSet ( the superclass ).
