### PR TITLE
Feature/cdbi implicit inflate

### DIFF
--- a/t/cdbi/70_implicit_inflate.t
+++ b/t/cdbi/70_implicit_inflate.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+
+# Class::DBI in its infinate wisdom allows implicit inflation
+# and deflation of foriegn clas looups in has_a relationships.
+# for inflate it would call ->new on the foreign_class and for
+# deflate it would "" the column value and allow for overloading
+# of the "" operator.
+
+use Test::More;
+use DBIx::Class::Optional::Dependencies;
+
+BEGIN {
+    plan skip_all => "Test needs ".DBIx::Class::Optional::Dependencies->req_missing_for('test_dt_sqlite')
+        unless DBIx::Class::Optional::Dependencies->req_ok_for('test_dt_sqlite');
+}
+
+use DateTime;
+
+INIT {
+    use lib 't/cdbi/testlib';
+    use ImplicitInflate;
+}
+
+ok(ImplicitInflate->can('db_Main'), 'set_db()');
+is(ImplicitInflate->__driver, "SQLite", 'Driver set correctly');
+
+my $now = DateTime->now;
+
+ImplicitInflate->create({
+    update_datetime => $now,
+    text            => "Test Data",
+});
+
+my $implicit_inflate = ImplicitInflate->retrieve(text => 'Test Data');
+
+ok($implicit_inflate->update_datetime->isa('DateTime'), 'Date column inflated correctly');
+is($implicit_inflate->update_datetime => $now, 'Date has correct year');
+
+done_testing;

--- a/t/cdbi/testlib/ImplicitInflate.pm
+++ b/t/cdbi/testlib/ImplicitInflate.pm
@@ -1,0 +1,42 @@
+package # Hide from PAUSE
+    ImplicitInflate;
+
+# Test class for the testing of Implicit inflation
+# in CDBI Classes using Compat layer
+# See t/cdbi/70-implicit_inflate.t
+
+use strict;
+use warnings;
+
+use base 'DBIC::Test::SQLite';
+
+__PACKAGE__->set_table('Date');
+
+__PACKAGE__->columns(Primary    => 'id');
+__PACKAGE__->columns(All        => qw/ update_datetime text/);
+
+__PACKAGE__->has_a(
+    update_datetime => 'MyDateStamp',
+);
+
+sub create_sql {
+       # SQLite doesn't support Datetime datatypes.
+    return qq{
+        id              INTEGER PRIMARY KEY,
+        update_datetime TEXT,
+        text            VARCHAR(20)
+    }
+}
+
+{
+    package MyDateStamp;
+
+    use DateTime::Format::SQLite;
+
+    sub new {
+        my ($self, $value) = @_;
+        return DateTime::Format::SQLite->parse_datetime($value);
+    }
+}
+
+1;


### PR DESCRIPTION
Class::DBI allows the foreign_class to be a non database class. e.g DateTime.

Inflation and deflation can be controlled either by supplying:

**PACKAGE**->has_a(accessor => 'Foreign::Class', inflate => sub {}, deflate => sub {});

however if inflate isn't supplied then CDBI will call: Foreign::Class->new($val) and if deflate is not supplied it will stringify "$val".

This behaviour is mostly used for inflation and deflation of datetime columns and should be emulated
