### PR TITLE
Unbreak $rs->create() with empty hashref on Oracle

### DIFF
--- a/lib/DBIx/Class/Storage/DBI/Oracle/Generic.pm
+++ b/lib/DBIx/Class/Storage/DBI/Oracle/Generic.pm
@@ -118,6 +118,21 @@ sub deployment_statements {
   $self->next::method($schema, $type, $version, $dir, $sqltargs, @rest);
 }
 
+sub insert {
+  my ($self, $source, $to_insert) = @_;
+
+  # Oracle does not understand INSERT INTO ... DEFAULT VALUES syntax
+  # Furthermore it does not have any way to insert without specifying any columns
+  # We can't fix this in SQLMaker::Oracle because it doesn't know which column to add to the statement
+  unless (%$to_insert)
+  {
+    my ($col) = $source->columns;
+    $to_insert = { $col => \'DEFAULT' };
+  }
+
+  return $self->next::method($source, $to_insert);
+}
+
 sub _dbh_last_insert_id {
   my ($self, $dbh, $source, @columns) = @_;
   my @ids = ();

--- a/t/60core.t
+++ b/t/60core.t
@@ -570,8 +570,10 @@ lives_ok (sub { my $newlink = $newbook->link}, "stringify to false value doesn't
 {
     my $new_artist = $schema->resultset('Artist')->new({});
     isa_ok( $new_artist, 'DBIx::Class::Row', '$rs->new gives a row object' );
+    lives_ok { $new_artist->insert() } 'inserting without specifying any columns works';
+    $new_artist->discard_changes;
+    $new_artist->delete;
 }
-
 
 # make sure we got rid of the compat shims
 SKIP: {

--- a/t/73oracle.t
+++ b/t/73oracle.t
@@ -201,6 +201,12 @@ sub _run_tests {
     like ($seq, qr/\.${q}artist_pk_seq${q}$/, 'Correct PK sequence selected for sqlt-like trigger');
   }
 
+  lives_ok {
+    $new = $schema->resultset('Artist')->create({});
+    $new->discard_changes;
+    ok $new->artistid, 'Created row has id'
+  } 'Create with empty hashref works';
+
 
 # test LIMIT support
   for (1..6) {


### PR DESCRIPTION
Oracle does not support the INSERT INTO ... DEFAULT VALUES syntax used by
SQLMaker by default. Furthermore, Oracle has no way of inserting a row
without specifying any columns, so the only reasonably fix seems to be to
pick a column and supply the DEFAULT keyword as value for it.

This approach seems to work without problems, even for things like
sequence+trigger-as-auto-increment.
