### PR TITLE
Don't rollback when TxnScopeGuard dtor is run twice

### DIFF
--- a/lib/DBIx/Class/Storage/TxnScopeGuard.pm
+++ b/lib/DBIx/Class/Storage/TxnScopeGuard.pm
@@ -106,6 +106,12 @@ sub DESTROY {
     }
   }
 
+  # Modules like Plack::Middleware::StackTrace save a reference to the
+  # guard object when a (nested) rollback exception is thrown resulting
+  # in the destructor being called twice. Inactivating the guard protects
+  # against trying to rollback a second time.
+  $self->{inactivated} = 1;
+
   $@ = $exception;
 }
 


### PR DESCRIPTION
Modules like Plack::Middleware::StackTrace save a reference to the
guard object when a (nested) rollback exception is thrown during
destruction resulting in the destructor being called twice. Inactivate
the guard after the first rollback.