### PR TITLE
Add _merge_joinpref_attr test w/ {}/undef (empty) vals

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -29,6 +29,7 @@ Gerda Shank <gshank@cpan.org>               <gerda.shank@gmail.com>
 Gianni Ceccarelli <dakkar@thenautilus.net>  <gianni.ceccarelli@net-a-porter.com>
 Gordon Irving <goraxe@cpan.org>             <goraxe@goraxe.me.uk>
 Hakim Cassimally <osfameron@cpan.org>       <hakim@vm-participo.(none)>
+Henry Van Styn <vanstyn@cpan.org>           <vanstyn@intellitree.com>
 Jason M. Mills <jmmills@cpan.org>           <jmmills@cpan.org>
 Jonathan Chu <milki@rescomp.berkeley.edu>   <milki@rescomp.berkeley.edu>
 Jose Luis Martinez <jlmartinez@capside.com> <jlmartinez@capside.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -199,6 +199,7 @@ triode: Pete Gamache <gamache@cpan.org>
 typester: Daisuke Murase <typester@cpan.org>
 uree: Oriol Soriano <oriol.soriano@capside.com>
 uwe: Uwe Voelker <uwe@uwevoelker.de>
+vanstyn: Henry Van Styn <vanstyn@cpan.org>
 victori: Victor Igumnov <victori@cpan.org>
 wdh: Will Hawes <wdhawes@gmail.com>
 wesm: Wes Malone <wes@mitsi.com>

--- a/t/91merge_joinpref_attr.t
+++ b/t/91merge_joinpref_attr.t
@@ -6,7 +6,7 @@ use lib qw(t/lib);
 use DBICTest;
 use Test::More;
 
-plan tests => 15;
+plan tests => 17;
 
 my $schema = DBICTest->init_schema();
 my $rs = $schema->resultset( 'CD' );
@@ -131,5 +131,20 @@ my $rs = $schema->resultset( 'CD' );
   is_deeply( $result, $expected );
 }
 
+{
+  my $a = [ { 'artist' => { 'manager' => {} } }, 'cd' ];
+  my $b = [ 'artist', { 'artist' => { 'manager' => {} } } ];
+  my $expected = [ { 'artist' => { 'manager' => {} } }, 'cd', { 'artist' => { 'manager' => {} } } ];
+  my $result = $rs->_merge_joinpref_attr($a, $b);
+  is_deeply( $result, $expected );
+}
+
+{
+  my $a = [ { 'artist' => { 'manager' => undef } }, 'cd' ];
+  my $b = [ 'artist', { 'artist' => { 'manager' => undef } } ];
+  my $expected = [ { 'artist' => { 'manager' => undef } }, 'cd', { 'artist' => { 'manager' => undef } } ];
+  my $result = $rs->_merge_joinpref_attr($a, $b);
+  is_deeply( $result, $expected );
+}
 
 1;


### PR DESCRIPTION
Added a test for the case of join attrs specified with empty ({} or
undef) vals (i.e. join => { rel => { rel2 => {} } }). These tests pass,
however, the empty {} vals currently produce uninitialized warnings.

For further reference, these warnings were bypassed for RapidApp in this
commit:

 https://github.com/vanstyn/RapidApp/commit/6f41f6e48

This test was added per the request of @ribasushi