### PR TITLE
add ResultSet::rs to force scalar context

### DIFF
--- a/lib/DBIx/Class/ResultSet.pm
+++ b/lib/DBIx/Class/ResultSet.pm
@@ -553,6 +553,36 @@ sub search_rs {
   return $rs;
 }
 
+=head2 rs
+
+=over 4
+
+=item Arguments: none
+
+=item Return Value: $resultset
+
+=back
+
+Returns the resultset.  Useful for forcing scalar context on search methods.
+
+ my %cd_rs_by_year = (
+     2000 => $cd_rs->search({ year => 2000 })->rs,
+     2001 => $cd_rs->search({ year => 2001 })->rs
+ );
+
+is equivalent to:
+
+ my %cd_rs_by_year = (
+     2000 => $cd_rs->search_rs({ year => 2000 }),
+     2001 => $cd_rs->search_rs({ year => 2001 })
+ );
+
+=cut
+
+sub rs {
+    return shift;
+}
+
 my $dark_sel_dumper;
 sub _normalize_selection {
   my ($self, $attrs) = @_;


### PR DESCRIPTION
rs is a simple helper method that does nothing but return the original
ResultSet in order to force scalar context for search methods.  This is
primarily intended for predefined queries in subclasses to allow them to
take advantage of search's context-aware return values without requiring
them to either manually force scalar context or define a second XXX_rs
search method to get a resultset object in list context.
