### PR TITLE
Added documentation for controlling precision for decimal and float.

### DIFF
--- a/lib/DBIx/Class/ResultSource.pm
+++ b/lib/DBIx/Class/ResultSource.pm
@@ -211,6 +211,12 @@ The length of your column, if it is a column type that can have a size
 restriction. This is currently only used to create tables from your
 schema, see L<DBIx::Class::Schema/deploy>.
 
+   { size => [ 9, 6 ] }
+
+For decimal or float values you can specify an ArrayRef in order to
+control precision, assuming your database's
+L<SQL::Translator::Producer> supports it.
+
 =item is_nullable
 
    { is_nullable => 1 }


### PR DESCRIPTION
In DBIx::Class::ResultSource
  Added pod outlining that an ArrayRef can be passed as the argument to
  size in order to control precision.

Feel free to let me know if this pull request should be against another branch or if you would prefer to include this documentation somewhere else or in another form.

Thank you for considering it!