### PR TITLE
linked "prefetch" in columns documentation; added whitespace after hash ...

### DIFF
--- a/lib/DBIx/Class/ResultSet.pm
+++ b/lib/DBIx/Class/ResultSet.pm
@@ -4081,13 +4081,13 @@ is the same as
     as     => [qw(some_column dbic_slot)]
 
 If you want to individually retrieve related columns (in essence perform
-manual prefetch) you have to make sure to specify the correct inflation slot
+manual L</prefetch>) you have to make sure to specify the correct inflation slot
 chain such that it matches existing relationships:
 
     my $rs = $schema->resultset('Artist')->search({}, {
         # required to tell DBIC to collapse has_many relationships
         collapse => 1,
-        join     => { cds => 'tracks'},
+        join     => { cds => 'tracks' },
         '+columns'  => {
           'cds.cdid'         => 'cds.cdid',
           'cds.tracks.title' => 'tracks.title',


### PR DESCRIPTION
10:42 < ether> cj: any suggestions for improving the docs?
10:43 < cj> let me look at the columns section...
10:44 < cj> I did see the "manual prefetch" section here and was curious how to do the non-manual version:
10:44 < cj> http://search.cpan.org/~ribasushi/DBIx-Class-0.082810/lib/DBIx/Class/ResultSet.pm#columns
10:44 < cj> so maybe link the word prefetch to the #prefetch ?
10:45 < cj> it would be even more clear if that block of code had a "produces the same thing as" with an example using prefetch =>
10:48 <@ilmari> the prefetch documentation shows the equivalence
10:48 <@ilmari> I think just a link is good enough
10:49 <@ilmari> also, that example can't be done with prefetch, since it doesn't fetch all the columns of cds and tracks
10:49 <@ilmari> but linking the word "prefetch" in "manual prefetch" is a good idea
10:50 <@mst> cj: an example that *is* equivalent would be helpful, yes
10:50 <@mst> maybe you could give it a go?
10:50 <@ilmari> the equivalence is demonstrated in the prefetch docs already
10:51 <@mst> might make the manual prefetch clearer though
10:51 <@mst> show the prefetch, show what that expands to, show the cut down version
10:52 < cj> mst: sure, got a git uri I can pull and munge?
10:54 <@ilmari> cj: https://github.com/dbsrgits/dbix-class
10:54 <@ilmari> pull requests are accepted
10:55 < cj> thanks
11:06 < cj> is there a definition of the example cds and tracks tables so that I can flesh out the 'columns' vs 'prefetch' examples?
11:06 < cj> I guess I would also need the artists table definition to make it accurate
11:06 < cj> s/artists/artist/
11:12 < ether> cj: have a look in t/lib in the repo
11:13 < cj> thanks
11:19 -!- mode/#dbix-class [+o castaway] by Bender
11:23 < shadowpaste> "cj" at 217.168.150.38 pasted "columns / prefetch example" (52 lines) at http://paste.scsys.co.uk/468508
11:23 < cj> how's that look?
11:23 < cj> I didn't run it.  Is there a .t file where we exercise the example code?
11:24 <@ilmari> that's really very verbose and detracts from the point of columns, IMO
11:24 <@ilmari> pretty much exactly the same example (but with getting the column names from the result source, and joining to genres as well), is in L</prefetch>
11:24 < cj> yeah, I was thinking the same sort of thing...
11:26 < cj> mst: do you think that just adding the link to prefetch would be sufficient?  I would have benefitted from knowing the concise version, but I may not be the target audience of that section...
11:26 <@ilmari> cj: L<prefetch> _has_ the concise version, then the expanded one
11:26 <@mst> ... doh
11:26 <@mst> I should've checked for that
11:26 <@ilmari> s/</<\//
11:27 <@ilmari> 18:50 <@ilmari> the equivalence is demonstrated in the prefetch docs already
11:27 <@ilmari> *cough*
11:27 <@mst> there is a difference between 'the equivalence is demonstrated' and 'the exact example you describe is already there' :P
11:32 < shadowpaste> "cj" at 217.168.150.38 pasted "fixing line wrap, linking prefetch, added appropriate whitespace after 'tracks'" (24 lines) at http://paste.scsys.co.uk/468509
11:32 < cj> better?
11:34  * ilmari would prefer it with no rewrapping, _just_ adding L</ > around prefetch
11:34 <@ilmari> for diff/blame tidyness, if nothing else
11:37 < cj> roger
