### PR TITLE
Fix a typo in the FAQ

### DIFF
--- a/lib/DBIx/Class/Manual/FAQ.pod
+++ b/lib/DBIx/Class/Manual/FAQ.pod
@@ -514,7 +514,7 @@ An another method is to use L<Moose> with your L<DBIx::Class> package.
 	package App::Schema::Result::MyTable;
 
 	use Moose; # import Moose
-	use Moose::Util::TypeConstraint; # import Moose accessor type constraints
+	use Moose::Util::TypeConstraints; # import Moose accessor type constraints
 
 	extends 'DBIx::Class::Core'; # Moose changes the way we define our parent (base) package
 


### PR DESCRIPTION
Looks like the module referred to in the POD example does not exist. Fix that.