### PR TITLE
Example syntax doesn't play with SQL::Abstract

### DIFF
--- a/lib/DBIx/Class/ResultSet.pm
+++ b/lib/DBIx/Class/ResultSet.pm
@@ -4572,7 +4572,7 @@ E.g.
 
 or with an in-place function in which case literal SQL is required:
 
-  having => \[ 'count(employee) >= ?', 100 ]
+  having => \[ 'count(employee) >= ?', [ {} => 100 ] ]
 
 =head2 distinct
 


### PR DESCRIPTION
You get errors like: `[SQL::Abstract::_assert_bindval_matches_bindtype] Fatal: bindtype 'columns' selected, you need to pass: [column_name => bind_value]`. Going through their documentation it should be written like in this commit.