### PR TITLE
Remove identity retrieval statement for blob inserts (Sybase)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -199,6 +199,7 @@ teejay: Aaron Trevena <teejay@cpan.org>
 theorbtwo: James Mastros <james@mastros.biz>
 Thomas Kratz <tomk@cpan.org>
 timbunce: Tim Bunce <tim.bunce@pobox.com>
+tinita: Tina Mueller <cpan2@tinita.de>
 Todd Lipcon
 Tom Hukins <tom@eborcom.com>
 tommy: Tommy Butler <tbutler.cpan.org@internetalias.net>

--- a/lib/DBIx/Class/Storage/DBI/Sybase/ASE.pm
+++ b/lib/DBIx/Class/Storage/DBI/Sybase/ASE.pm
@@ -791,6 +791,9 @@ sub _insert_blobs {
   $self->throw_exception('Cannot update TEXT/IMAGE column(s) without primary key values')
     if ((grep { defined $row{$_} } @primary_cols) != @primary_cols);
 
+  # do not perform identity retrieval on blob inserts
+  local $self->{_perform_autoinc_retrieval} = undef;
+
   for my $col (keys %$blob_cols) {
     my $blob = $blob_cols->{$col};
 

--- a/t/746sybase.t
+++ b/t/746sybase.t
@@ -490,6 +490,14 @@ SQL
       $rs->update({ blob => undef });
       is((grep !defined($_->blob), $rs->all), 2);
     } 'blob update to NULL';
+
+    lives_ok {
+        $schema->txn_do(sub {
+              my $created = $rs->create( { clob => "some text" } );
+          });
+    } 'insert blob field in transaction';
+    $ping_count-- if $@; # dbh_do calls ->connected
+
   }
 
 # test MONEY column support (and some other misc. stuff)


### PR DESCRIPTION
See https://gist.github.com/perlpunk/ab26c0d56f29bf29b747

When you have a table in Sybase with a text column, and you do an insert,
this will fail if you do it in a transaction because a
"SELECT MAX(id) ..." is appended to the SQL performing the blob insert.
Without a transaction a new $schema object is used which does not have
the _perform_autoinc_retrieval attribute set, so it suceeds

