### PR TITLE
Fix 'select from dual' (oracle) example in Cookbook.

### DIFF
--- a/lib/DBIx/Class/Manual/Cookbook.pod
+++ b/lib/DBIx/Class/Manual/Cookbook.pod
@@ -1491,8 +1491,17 @@ Once you've loaded your table class select from it using C<select>
 and C<as> instead of C<columns>
 
   my $rs = $schema->resultset('Dual')->search(undef,
-    { select => [ 'sydate' ],
+    { select => [ \'sydate' ],
       as     => [ 'now' ]
+    },
+  );
+
+You can pass parameters to your function like this
+
+  my $rs = $schema->resultset('Dual')->search(undef,
+    { select => [ \'MyDBProc(?,?,?)' ],
+      as     => [ 'ProcResult' ],
+      bind   => [ $param1, $param2, $param3 ]
     },
   );
 


### PR DESCRIPTION
Add backslash to the function name.
Add another example with parameters to the function call.