### PR TITLE
Avoid infinite loop calling svp_release()

### DIFF
--- a/lib/DBIx/Class/Storage.pm
+++ b/lib/DBIx/Class/Storage.pm
@@ -433,7 +433,9 @@ sub svp_release {
     my @stack = @{ $self->savepoints };
     my $svp;
 
-    do { $svp = pop @stack } until $svp eq $name;
+    while (@stack and $stack[-1] ne $name) {
+      $svp = pop @stack
+    };
 
     $self->throw_exception ("Savepoint '$name' does not exist")
       unless $svp;

--- a/lib/DBIx/Class/Storage.pm
+++ b/lib/DBIx/Class/Storage.pm
@@ -431,9 +431,9 @@ sub svp_release {
 
   if (defined $name) {
     my @stack = @{ $self->savepoints };
-    my $svp;
+    my $svp   = pop @stack;
 
-    while (@stack and $stack[-1] ne $name) {
+    while (@stack and $svp ne $name) {
       $svp = pop @stack
     };
 

--- a/lib/DBIx/Class/Storage.pm
+++ b/lib/DBIx/Class/Storage.pm
@@ -438,7 +438,7 @@ sub svp_release {
     };
 
     $self->throw_exception ("Savepoint '$name' does not exist")
-      unless $svp;
+      unless $svp and $svp eq $name;
 
     $self->savepoints(\@stack); # put back what's left
   }


### PR DESCRIPTION
We hit a bug in our tests when we rolled back twice to the same savepoint. Although this was our bug we only found out when the test never never completed and used much CPU on a Jenkins box.
