### PR TITLE
Scalar::Defer support as column name

### DIFF
--- a/lib/DBIx/Class/Storage/DBIHacks.pm
+++ b/lib/DBIx/Class/Storage/DBIHacks.pm
@@ -1197,7 +1197,7 @@ sub _collapse_cond {
           $fin_idx->{ "SER_" . serialize $sub_elt } = $sub_elt;
         }
       }
-      elsif (! length ref $where->[$i] ) {
+      elsif (! ref $where->[$i] ) {
         my $sub_elt = $self->_collapse_cond({ @{$where}[$i, $i+1] })
           or next;
 


### PR DESCRIPTION
So then using Scalar::Defer (or any other defer module) object as column name in search(), code call ref on it, in case of Scalar::Defer ref eq "0", and if we check length it will be == 1, so condition is false and it falls to "else" condition, which treat defer object as subject for serialize. However, serialize is using Storable::freeze, which has a line "logcroak "not a reference" unless ref($self);" and for defer object that is true, so it croaks.
I also tried to re-bless it into different package, not "0", but it only fails in different place instead. This looks like best solution for me, would be better if there was any certain way of knowing if object can be stringified and use that, but I don't see it yet.