### PR TITLE
Fix parsing driver names from DSN when the middle part includes DBI attributes

### DIFF
--- a/lib/DBIx/Class/Storage/DBI.pm
+++ b/lib/DBIx/Class/Storage/DBI.pm
@@ -1377,7 +1377,10 @@ sub _extract_driver_from_connect_info {
     # try to use dsn to not require being connected, the driver may still
     # force a connection later in _rebless to determine version
     # (dsn may not be supplied at all if all we do is make a mock-schema)
-    ($drv) = ($self->_dbi_connect_info->[0] || '') =~ /^dbi:([^:]+):/i;
+
+    # be careful when parsing DSNs that the driver name may include
+    # DBI attributes, e.g. "mysql(Username=bob)"
+    ($drv) = ($self->_dbi_connect_info->[0] || '') =~ /^dbi:([^:(]+)[:(]/i;
     $drv ||= $ENV{DBI_DRIVER};
   }
 

--- a/t/storage/dbi_env.t
+++ b/t/storage/dbi_env.t
@@ -79,6 +79,10 @@ $schema = DBICTest::Schema->connect("dbi:SQLite:$dbname");
 lives_ok { count_sheep($schema) } 'SQLite passed to connect_info';
 isa_ok $schema->storage, 'DBIx::Class::Storage::DBI::SQLite';
 
+$schema = DBICTest::Schema->connect("dbi:SQLite(ReadOnly=1):$dbname");
+lives_ok { count_sheep($schema) } 'SQLite passed to connect_info despite extra arguments present';
+isa_ok $schema->storage, 'DBIx::Class::Storage::DBI::SQLite';
+
 $ENV{DBI_DRIVER} = 'SQLite';
 $schema = DBICTest::Schema->connect("dbi::$dbname");
 lives_ok { count_sheep($schema) } 'SQLite in DBI_DRIVER';


### PR DESCRIPTION
According to [parse_dsn](https://metacpan.org/pod/DBI#parse_dsn), the middle part of a DSN may include DBI attributes. Currently the driver name extracted from a DSN includes everything up to the next colon, which makes DBIC think it is not supported.