### PR TITLE
PostgreSQL hot-standby replication support

### DIFF
--- a/lib/DBIx/Class/Storage/DBI/Pg.pm
+++ b/lib/DBIx/Class/Storage/DBI/Pg.pm
@@ -237,6 +237,23 @@ sub deployment_statements {
   $self->next::method($schema, $type, $version, $dir, $sqltargs, @rest);
 }
 
+sub is_replicating {
+    my $repl = 'select pg_last_xlog_receive_location() AS replicating';
+    my $status = shift->_get_dbh->selectrow_hashref($repl);
+    return 1 if defined $status->{replicating};
+    return 0;
+}
+
+sub lag_behind_master {
+    my $repl = 'SELECT '
+        .'CASE WHEN pg_last_xlog_receive_location() = pg_last_xlog_replay_location() '
+        .'THEN 0 '
+        .'ELSE EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())'
+        .'END AS log_delay';
+    my $status = shift->_get_dbh->selectrow_hashref($repl);
+    return $status->{log_delay};
+}
+
 1;
 
 __END__


### PR DESCRIPTION
Hello!

We have been using some customizations to DBIx::Class::Storage::DBI::Pg for a while, which makes DBIx::Class replication-aware for Postgres.  I'd like to push the changes upstream.

The changes work with PostgreSQL hot-standby replication, which was introduced in PostgreSQL 9.0.  I don't know if it would work in other forms of PostgreSQL master-slave replication (such as Slony); I'm sure it won't work with PostgreSQL master-master replication (such as BDR), although I'm not sure you'd even want to use this in a multi-master environment.

The code was written by a co-worker, but I've gotten his OK to push this upstream.