### PR TITLE
Treat undef like blessed objects for the purpose of looking for special handling

### DIFF
--- a/lib/DBIx/Class/Row.pm
+++ b/lib/DBIx/Class/Row.pm
@@ -1101,7 +1101,7 @@ sub set_inflated_columns {
   my ( $self, $upd ) = @_;
   my $rsrc;
   foreach my $key (keys %$upd) {
-    if (ref $upd->{$key}) {
+    if (!defined $upd->{$key} || ref $upd->{$key}) {
       $rsrc ||= $self->result_source;
       my $info = $rsrc->relationship_info($key);
       my $acc_type = $info->{attrs}{accessor} || '';


### PR DESCRIPTION
Suppose `foo` is an inflated timestamp column and `$row->foo` is set to a true DateTime (representing a date, say, 2016-06-23T16:42:34).  In the present code, these two code snippets:

    $row->set_inflated_column(foo => undef);
    say 'The value is: '.$row->get_column('foo');
    say 'The value is: '.$row->foo;

    $row->set_inflated_columns({ foo => undef, });
    say 'The value is: '.$row->get_column('foo');
    say 'The value is: '.$row->foo;

would do different things.  The first prints

    The value is: 
    The value is: 

the second prints

    The value is: 
    The value is: 2016-06-23T16:42:34

Because `update` uses `set_inflated_columns`, the same behavior is visible there.

This change makes `set_inflated_columns` call `set_inflated_column` when the column is inflated and new value is `undef` (which `set_inflated_column` handles correctly), which causes the two functions to behave identically in this case, which seems like the correct behavior.