### PR TITLE
Less stringent column name checking in __strip_relcond

### DIFF
--- a/lib/DBIx/Class/ResultSource.pm
+++ b/lib/DBIx/Class/ResultSource.pm
@@ -1875,7 +1875,7 @@ sub reverse_relationship_info {
 sub __strip_relcond {
   +{
     map
-      { map { /^ (?:foreign|self) \. (\w+) $/x } ($_, $_[1]{$_}) }
+      { map { /^ (?:foreign|self) \. (.+) $/x } ($_, $_[1]{$_}) }
       keys %{$_[1]}
   }
 }


### PR DESCRIPTION
If (like us) you are using some strange syntax for column names the \w+ regex
breaks returning () which leads to an incorrect hash.
