### PR TITLE
set_cache should invalidate existing related_resultset

### DIFF
--- a/lib/DBIx/Class/ResultSet.pm
+++ b/lib/DBIx/Class/ResultSet.pm
@@ -3220,6 +3220,14 @@ sub set_cache {
   my ( $self, $data ) = @_;
   $self->throw_exception("set_cache requires an arrayref")
       if defined($data) && (ref $data ne 'ARRAY');
+
+  # If set_cache is called after a related resultset has been created,
+  # we expect subsequent calls to related_resultset to include cached
+  # results (if they are present on the objects in $data).
+  #
+  # This won't be true if we've cached the related_resultsets already,
+  # so clear them.
+  $self->{related_resultsets} = {};
   $self->{all_cache} = $data;
 }
 

--- a/t/resultset/cache.t
+++ b/t/resultset/cache.t
@@ -1,0 +1,56 @@
+BEGIN { do "./t/lib/ANFANG.pm" or die ( $@ || $! ) }
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+
+use DBICTest;
+
+my $schema = DBICTest->init_schema();
+
+# Test how related_resultset and set_cache interact
+
+for my $i (0, 1) {
+
+  # We do this twice for comparison.
+  #
+  # The first time we will just set the cache and get the related resultset.
+  #
+  # The second time we will additionally get $cd_rset->related_resultset('artist') first.
+  #
+  # You would think this would have no effect on the second call.
+  #
+  # In 0.082840, however, this has the undesirable effect that even after set_cache is called,
+  # subsequent calls to $cd_rset->related_resultset('artist') reuse the previously generated resultset,
+  # instead of returning a resultset with the items from the cache.
+  #
+  # This would cause the final test to fail.
+
+  my @tracks = $schema->resultset('Track')->search({ title => 'Apiary' });
+
+  my $cd_rset = $tracks[0]->related_resultset('cd');
+
+  my @cds = $schema->resultset('CD')->search({ cdid => 1 }, { prefetch => 'artist' });
+
+  my ($artist_rset_before, $artist_rset_after);
+
+  if ($i) {
+    $artist_rset_before = $cd_rset->related_resultset('artist');
+  }
+
+  $cd_rset->set_cache(\@cds);
+
+  $artist_rset_after = $cd_rset->related_resultset('artist');
+
+  is scalar $cd_rset, 1, 'Track should belong to a CD';
+  is scalar @{ $cd_rset->get_cache // [] }, 1, 'CD cache should contain one item';
+
+  is scalar $cd_rset->related_resultset('artist'), 1, 'Track should belong to an Artist';
+
+  # The following fails when DBIx::Class::ResultSet::set_cache does not clear related resultsets
+  is scalar @{ $artist_rset_after->get_cache // [] }, 1, 'Artist cache should contain one item';
+}
+
+done_testing;


### PR DESCRIPTION
In `DBIx::Class::ResultSet::related_resultset`, if the current resultset has a cache of results, the rows in that cache are checked for related objects which can be used to populate the cache belonging to the related resultset which is going to be returned. 

However, the related resultset objects themselves are also stored on `$self` in a cache (`$self->{'related_resultsets'}`), so that this process is skipped if the related resultset has already been created in a previous call to `related_resultset`. 

This means that if the cache is set after a related resultset has been created, subsequent calls to `related_resultset` retrieve the existing resultset; because it was created before the cache existed, it either has no cache of its own, or has a cache which potentially contradicts the cache in set_cache. 

There is no user-facing way to 'undo' the creation of a cached related resultset, nor is it obvious from the docs that this might be useful or necessary (not to mention why it should be). In fact, the docs don't even mention that related resultsets are cached. 

For example: in this case `$artist` is an arrayref of one item: 

    $cd_rset->set_cache(\@cds);
    my $artist_rset_after = $cd_rset->related_resultset('artist');
    my $artist = $artist_rset_after->get_cache();

... whereas in this case `$artist` is `undef`:

    my $artist_rset_before = $cd_rset->related_resultset('artist');
    $cd_rset->set_cache(\@cds);
    my $artist_rset_after = $cd_rset->related_resultset('artist');
    my $artist = $artist_rset_after->get_cache();

I see two potential solutions:

1. When `$self->set_cache` is called, clear `$self->{'related_resultsets'}`. New calls to `related_resultset` would return new resultsets with the correct cache. Resultsets previously created would be unchanged.

2. When `$self->set_cache` is called, populate the cache for each resultset in `$self->{'related_resultsets'}`. This may be surprising if those resultsets have also previously populated a cache. Furthermore, what ought to happen if `\@cds` do not all have a populated cache in their `related_resultset` for a given relationship. Should the cache on the existing resultset be emptied, or should it be left alone?

I feel that option 1 is the cleanest solution.

This PR introduces:

- A currently-failing test which demonstrates the issue
- A one-line-plus-comments fix, following the first solution.
