### PR TITLE
clarify result_class attribute of ResultSet objects

### DIFF
--- a/lib/DBIx/Class/ResultClass/HashRefInflator.pm
+++ b/lib/DBIx/Class/ResultClass/HashRefInflator.pm
@@ -34,14 +34,22 @@ from a massive resultset, while skipping the creation of fancy result objects.
 Specifying this class as a C<result_class> for a resultset will change C<< $rs->next >>
 to return a plain data hash-ref (or a list of such hash-refs if C<< $rs->all >> is used).
 
-There are two ways of applying this class to a resultset:
+There are three ways of applying this class to a resultset:
 
 =over
 
 =item *
 
-Specify C<< $rs->result_class >> on a specific resultset to affect only that
-resultset (and any chained off of it); or
+Specify C<< $rs->result_class >> on a specific resultset to affect only
+that resultset object (if you are going to immediately call C<find>,
+C<next>, C<all>, or another result method).
+
+=item *
+
+Specify C<< $rs->search({}, { result_class => '...' }) >> to affect this
+resultset and any further resultset objects created from this one. Use
+this if you are chaining additional calls to C<search> and want the final
+results to be hash-refs.
 
 =item *
 

--- a/lib/DBIx/Class/ResultSet.pm
+++ b/lib/DBIx/Class/ResultSet.pm
@@ -1546,6 +1546,11 @@ that were originally loaded in the source class via
 L<load_components|Class::C3::Componentised/load_components( @comps )>.
 Any overloaded methods in the original source class will not run.
 
+Setting the result_class with this method will change the class only for
+this resultset instance. Setting the result_class using the C<search>
+C<%attrs> hash will change the class for this resultset and any
+resultset chained from this resultset.
+
 =cut
 
 sub result_class {
@@ -4664,6 +4669,12 @@ L<DBIx::Class::Manual::Cookbook>.
 Set to 'update' for a SELECT ... FOR UPDATE or 'shared' for a SELECT
 ... FOR SHARED. If \$scalar is passed, this is taken directly and embedded in the
 query.
+
+=head2 result_class
+
+Set the result_class attribute for this resultset and any resultset chained
+from this resultset. This differs from using the L</result_class> accessor:
+The accessor is not chained and only applies to the current resultset.
 
 =head1 PREFETCHING
 


### PR DESCRIPTION
This replaces #21 to add similar documentation to the ResultSet class
itself, explaining how the accessor method differs in behavior from the
attributes passed in to the search() method.