### PR TITLE
use base before namespace::clean

### DIFF
--- a/lib/DBIx/Class/CDBICompat/LiveObjectIndex.pm
+++ b/lib/DBIx/Class/CDBICompat/LiveObjectIndex.pm
@@ -5,9 +5,10 @@ use strict;
 use warnings;
 
 use Scalar::Util qw/weaken/;
-use namespace::clean;
 
 use base 'DBIx::Class';
+
+use namespace::clean;
 
 __PACKAGE__->mk_classdata('purge_object_index_every' => 1000);
 __PACKAGE__->mk_classdata('live_object_index' => { });

--- a/lib/DBIx/Class/Storage/DBI/Sybase.pm
+++ b/lib/DBIx/Class/Storage/DBI/Sybase.pm
@@ -3,9 +3,10 @@ package DBIx::Class::Storage::DBI::Sybase;
 use strict;
 use warnings;
 use DBIx::Class::_Util qw( dbic_internal_try dbic_internal_catch );
-use namespace::clean;
 
 use base qw/DBIx::Class::Storage::DBI/;
+
+use namespace::clean;
 
 =head1 NAME
 

--- a/lib/DBIx/Class/Storage/DBI/Sybase/MSSQL.pm
+++ b/lib/DBIx/Class/Storage/DBI/Sybase/MSSQL.pm
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 use DBIx::Class::Carp;
-use namespace::clean;
 
 carp 'Setting of storage_type is redundant as connections through DBD::Sybase'
     .' are now properly recognized and reblessed into the appropriate subclass'
@@ -17,6 +16,8 @@ carp 'Setting of storage_type is redundant as connections through DBD::Sybase'
 
 use base qw/DBIx::Class::Storage::DBI::Sybase::Microsoft_SQL_Server/;
 use mro 'c3';
+
+use namespace::clean;
 
 1;
 

--- a/lib/SQL/Translator/Parser/DBIx/Class.pm
+++ b/lib/SQL/Translator/Parser/DBIx/Class.pm
@@ -18,9 +18,10 @@ use DBIx::Class::Carp qw/^SQL::Translator|^DBIx::Class|^Try::Tiny/;
 use DBIx::Class::_Util qw( dbic_internal_try dbic_internal_catch bag_eq );
 use Class::C3::Componentised;
 use Scalar::Util 'blessed';
-use namespace::clean;
 
 use base qw(Exporter);
+
+use namespace::clean;
 
 @EXPORT_OK = qw(parse);
 


### PR DESCRIPTION
namespace::clean uses the hints hash to track when it should do its
work.  Without extra protection, using hints across nested module
loads can crash on perl <= 5.8.3.  Older versions of base.pm used a
string eval, which served to provide the isolation needed to avoid the
bug.

Moving the use base before the use namespace::clean means the hints
aren't used until after the other modules are loaded, which avoids this
issue.

An alternate workaround would involve localizing the hints, but this
involves intercepting the module loads.  This would mean using something
like Module::Runtime or Lexical::SealRequireHints, although those modules
don't currently provide the localization needed to workaround this
specific issue.