### PR TITLE
Fix bug in resolve_relationship_condition with sources with virtual columns

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,11 +5,6 @@ Current Known Issues / Regressions
 Revision history for DBIx::Class
 
     * Notable Changes and Deprecations
-        - The entire class hierarchy now explicitly sets the 'c3' mro, even
-          in cases where load_components was not used. Extensive testing led
-          the maintainer believe this is safe, but this is a very complex
-          area and reality may turn out to be different. If **ANYHTING** at
-          all seems out of place, please file a report at once
         - The unique constraint info (including the primary key columns) is no
           longer shared between related (class and schema-level) ResultSource
           instances. If your app stops working with no obvious pointers, set

--- a/maint/gen_pod_inherit
+++ b/maint/gen_pod_inherit
@@ -65,6 +65,7 @@ Pod::Inherit->new({
       DBIx::Class::Componentised
       Class::C3::Componentised
       DBIx::Class::AccessorGroup
+      DBIx::Class::MethodAttributes
       Class::Accessor::Grouped
       Moose::Object
       Exporter

--- a/t/cdbi/06-hasa.t
+++ b/t/cdbi/06-hasa.t
@@ -118,7 +118,7 @@ sub fail_with_bad_object {
         NumExplodingSheep => 23
       }
     );
-  } qr/is not a column on related source 'Director'/;
+  } qr/isn't a Director/;
 }
 
 package Foo;

--- a/t/cdbi/18-has_a.t
+++ b/t/cdbi/18-has_a.t
@@ -110,7 +110,7 @@ is(
         Rating            => 'R',
         NumExplodingSheep => 23
       });
-  } qr/is not a column on related source 'Director'/, "Can't have film as codirector";
+  } qr/isn't a Director/, "Can't have film as codirector";
   is $fail, undef, "We didn't get anything";
 
   my $tastes_bad = YA::Film->create({


### PR DESCRIPTION
Commits needed to fix bug revealed by RapidApp test case in this commit:

 * https://github.com/vanstyn/RapidApp/commit/c319a41904

Huge thanks to @ribasushi for identifing the needed code changes (namely
473491688bd44) to fix the bug once I was able to provide the failing
test case in RapidApp