### PR TITLE
RT-112563 Correct documentation for get_column arguments

### DIFF
--- a/lib/DBIx/Class/ResultSet.pm
+++ b/lib/DBIx/Class/ResultSet.pm
@@ -1146,7 +1146,7 @@ sub single {
 
 =over 4
 
-=item Arguments: L<$cond?|DBIx::Class::SQLMaker>
+=item Arguments: $column
 
 =item Return Value: L<$resultsetcolumn|DBIx::Class::ResultSetColumn>
 


### PR DESCRIPTION
This addresses https://rt.cpan.org/Ticket/Display.html?id=112563 by changes the arguments for get_columns to '$column'.