### PR TITLE
RT-119863 Improve error message when the related_resultset is not found.

### DIFF
--- a/lib/DBIx/Class/Relationship/Base.pm
+++ b/lib/DBIx/Class/Relationship/Base.pm
@@ -527,7 +527,9 @@ sub related_resultset {
   my $rsrc = $self->result_source;
 
   my $rel_info = $rsrc->relationship_info($rel)
-    or $self->throw_exception( "No such relationship '$rel'" );
+    or $self->throw_exception(
+      "No such relationship '$rel' on '@{[ $rsrc->source_name ]}' source"
+    );
 
   my $relcond_is_freeform = ref $rel_info->{cond} eq 'CODE';
 


### PR DESCRIPTION
This addresses https://rt.cpan.org/Ticket/Display.html?id=119863 by changing the error message to include the name of the source resultset.