### PR TITLE
RT-123495 Fix failing tests in t/72pg.t

### DIFF
--- a/t/72pg.t
+++ b/t/72pg.t
@@ -509,7 +509,7 @@ lives_ok { $cds->update({ year => '2010' }) } 'Update on prefetched rs';
     like $@, qr/violates foreign key constraint/i,
       "Still expected exception on deferred failure at commit time";
 
-  } [], 'No warnings on deferred rollback';
+  } [qr/SET CONSTRAINTS can only be used in transaction blocks/], 'No warnings on deferred rollback';
 }
 
 done_testing;


### PR DESCRIPTION
This addresses https://rt.cpan.org/Ticket/Display.html?id=123494 by adding the expected warning in the call to warnings_like on line 512.