### PR TITLE
clear inflated in update({column => deflated})

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@
 
 abraxxa: Alexander Hartmaier <abraxxa@cpan.org>
 acca: Alexander Kuznetsov <acca@cpan.org>
+aeruder: Andrew Ruder <aeruder@ziprecruiter.com>
 aherzog: Adam Herzog <adam@herzogdesigns.com>
 Alexander Keusch <cpan@keusch.at>
 alexrj: Alessandro Ranellucci <aar@cpan.org>

--- a/lib/DBIx/Class/Row.pm
+++ b/lib/DBIx/Class/Row.pm
@@ -975,6 +975,7 @@ sub set_column {
         delete $self->{_inflated_column}{$rel_name};
       }
     }
+    delete $self->{_inflated_column}{$column};
 
     if (
       # value change from something (even if NULL)

--- a/t/inflate/datetime.t
+++ b/t/inflate/datetime.t
@@ -146,4 +146,54 @@ is ("$skip_inflation", '2006-04-21 18:04:06', 'Correct date/time');
   }
 }
 
+{
+  my %required_create_args = (
+    starts_at => "2012-01-01",
+    created_on => "2012-01-01",
+    varchar_datetime => DateTime->new(year => 2016, month => 01, day => 01),
+  );
+
+# create with DateTime
+  my $created = $schema->resultset('Event')->create({ %required_create_args });
+  $created->varchar_datetime; # make sure inflated
+  isa_ok $created->varchar_datetime, "DateTime", "varchar_datetime accessor is a datetime";
+  is $created->varchar_datetime->date, "2016-01-01", "varchar_datetime has correct datetime";
+
+# create with scalar
+  $created = $schema->resultset('Event')->create({ %required_create_args, varchar_datetime => "2016-01-01" });
+  $created->varchar_datetime; # make sure inflated
+  isa_ok $created->varchar_datetime, "DateTime", "varchar_datetime accessor is a datetime";
+  is $created->varchar_datetime->date, "2016-01-01", "varchar_datetime has correct datetime";
+
+# update via column with DateTime
+  $created = $schema->resultset('Event')->create({ %required_create_args });
+  $created->varchar_datetime; # make sure inflated
+  $created->varchar_datetime(DateTime->new(year => 2017, month => 01, day => 01));
+  $created->update;
+  isa_ok $created->varchar_datetime, "DateTime", "varchar_datetime accessor is a datetime";
+  is $created->varchar_datetime->date, "2017-01-01", "varchar_datetime has correct datetime";
+
+# update via column with scalar
+  $created = $schema->resultset('Event')->create({ %required_create_args });
+  $created->varchar_datetime; # make sure inflated
+  $created->varchar_datetime("2017-01-01");
+  $created->update;
+  isa_ok $created->varchar_datetime, "DateTime", "varchar_datetime accessor is a datetime";
+  is $created->varchar_datetime->date, "2017-01-01", "varchar_datetime has correct datetime";
+
+# update directly with DateTime
+  $created = $schema->resultset('Event')->create({ %required_create_args });
+  $created->varchar_datetime; # make sure inflated
+  $created->update({varchar_datetime => DateTime->new(year => 2017, month => 01, day => 01)});
+  isa_ok $created->varchar_datetime, "DateTime", "varchar_datetime accessor is a datetime";
+  is $created->varchar_datetime->date, "2017-01-01", "varchar_datetime has correct datetime";
+
+# update directly with scalar
+  $created = $schema->resultset('Event')->create({ %required_create_args });
+  $created->varchar_datetime; # make sure inflated
+  $created->update({varchar_datetime => "2017-01-01"});
+  isa_ok $created->varchar_datetime, "DateTime", "varchar_datetime accessor is a datetime";
+  is $created->varchar_datetime->date, "2017-01-01", "varchar_datetime has correct datetime";
+};
+
 done_testing;


### PR DESCRIPTION
If you access an inflated column and then change it with update({column
=> deflated_value}), the cached inflated column isn't cleared out and
returns stale values.

Added a small test exhibiting the problem with a datetime field.