### PR TITLE
Stop trying to get last_insert_id() from all the columns

### DIFF
--- a/lib/DBIx/Class/Storage/DBI.pm
+++ b/lib/DBIx/Class/Storage/DBI.pm
@@ -2122,7 +2122,7 @@ sub insert {
   }
   else {
     # pull in PK if needed and then everything else
-    if (my @missing_pri = grep { $pcols{$_} } keys %retrieve_cols) {
+    if (my @missing_pri = grep { $pcols{$_} && ($col_infos->{$_}->{'is_auto_increment'} || $col_infos->{$_}->{'retrieve_on_insert' }) } keys %retrieve_cols) {
 
       $self->throw_exception( "Missing primary key but Storage doesn't support last_insert_id" )
         unless $self->can('last_insert_id');


### PR DESCRIPTION
Hello,

When we're trying to create a new row in a table having a complex PK (like `int+datetime+datetime` in my case), we're getting a `Can't get last insert id` exception, as datetime doesn't return anything to a `last_insert_id` call, so `@pri_values != @missing_pri` in such case.

So I'd like to propose to filter out the columns that don't have the `is_auto_increment` attribute set. Would you be so kind as to review it? Thanks!