### PR TITLE
Use deep merge for column info when adding columns

### DIFF
--- a/lib/DBIx/Class/ResultSource.pm
+++ b/lib/DBIx/Class/ResultSource.pm
@@ -10,6 +10,7 @@ use DBIx::Class::ResultSourceHandle;
 
 use DBIx::Class::Carp;
 use DBIx::Class::_Util 'UNRESOLVABLE_CONDITION';
+use Hash::Merge ();
 use SQL::Abstract 'is_literal_value';
 use Devel::GlobalDestruction;
 use Try::Tiny;
@@ -346,7 +347,7 @@ sub add_columns {
     # use an empty hashref
     if (ref $cols[0]) {
       my $new_info = shift(@cols);
-      %$column_info = (%$column_info, %$new_info);
+      %$column_info = %{ Hash::Merge::merge($column_info, $new_info) };
     }
     push(@added, $col) unless exists $columns->{$col};
     $columns->{$col} = $column_info;


### PR DESCRIPTION
The add_columns method uses a shallow merge of column
information.  But the problem is that information in
"extra" is overwritten rather than merged.

This fixes the following issue:

    __PACKAGE__->add_column(
      x => {
        data_type => 'enum',
        extra     => {
          list => [qw/ success fail /],
        }
      }
    );

    __PACKAGE__->add_column(
      '+x' => {
        extra => {
          something_else => ...
        }
      }
    );