### PR TITLE
Column names can include spaces and other non 'w' characters

### DIFF
--- a/lib/DBIx/Class/ResultSource.pm
+++ b/lib/DBIx/Class/ResultSource.pm
@@ -1531,7 +1531,7 @@ sub reverse_relationship_info {
 sub __strip_relcond {
   +{
     map
-      { map { /^ (?:foreign|self) \. (\w+) $/x } ($_, $_[1]{$_}) }
+      { map { /^ (?:foreign|self) \. (.+) $/x } ($_, $_[1]{$_}) }
       keys %{$_[1]}
   }
 }


### PR DESCRIPTION
MSSQL allows spaces (and other non-word characters) in column names. At the point that this code is executed we are looking at column names and not accessors,