### PR TITLE
fix example in manual

### DIFF
--- a/lib/DBIx/Class/Manual/ResultClass.pod.proto
+++ b/lib/DBIx/Class/Manual/ResultClass.pod.proto
@@ -16,7 +16,7 @@ a DB query
 
   __PACKAGE__->table('tracks');
 
-  __PACKAGE__->add_columns({
+  __PACKAGE__->add_columns(
     id => {
       data_type => 'int',
       is_auto_increment => 1,
@@ -32,7 +32,7 @@ a DB query
       data_type => 'int',
       is_nullable => 1,
     },
-  });
+  );
 
   __PACKAGE__->set_primary_key('id');
   __PACKAGE__->add_unique_constraint(u_title => ['cd_id', 'title']);


### PR DESCRIPTION
With the hashref as an argument to `add_columns`, the example throws an error during `set_primary_key`: `{UNKNOWN}: DBIx::Class::ResultSource::columns_info(): No such column 'id' on source 'tracks'`. Removing the hashref fixes this error.