### PR TITLE
DateTime::Format::* does not have format_timestamp_without_timezone m…

### DIFF
--- a/lib/DBIx/Class/InflateColumn/DateTime.pm
+++ b/lib/DBIx/Class/InflateColumn/DateTime.pm
@@ -132,10 +132,10 @@ sub register_column {
   # _ic_dt_method will follow whatever the registration requests
   # thus = instead of ||=
   if ($data_type eq 'timestamp with time zone' || $data_type eq 'timestamptz') {
-    $info->{_ic_dt_method} = 'timestamp_with_timezone';
+    $info->{_ic_dt_method} = 'timestamp_with_time_zone';
   }
   elsif ($data_type eq 'timestamp without time zone') {
-    $info->{_ic_dt_method} = 'timestamp_without_timezone';
+    $info->{_ic_dt_method} = 'timestamp_without_time_zone';
   }
   elsif ($data_type eq 'smalldatetime') {
     $info->{_ic_dt_method} = 'smalldatetime';

--- a/t/inflate/datetime_pg.t
+++ b/t/inflate/datetime_pg.t
@@ -30,9 +30,11 @@ warnings_are {
 # test 'timestamp without time zone'
   my $dt = DateTime->from_epoch(epoch => time);
   $dt->set_nanosecond(int 500_000_000);
+  $dt->set_time_zone( "Europe/Zaporozhye" );
   $event->update({ts_without_tz => $dt});
   $event->discard_changes;
   isa_ok($event->ts_without_tz, "DateTime") or diag $event->created_on;
+  is($event->ts_without_tz->time_zone->name, "floating", "No specific timezone");
   is($event->ts_without_tz, $dt, 'timestamp without time zone inflation');
   is($event->ts_without_tz->microsecond, $dt->microsecond,
     'timestamp without time zone microseconds survived');


### PR DESCRIPTION
FIXES: [RT133622](https://rt-cpan.github.io/Public/Bug/Display/133622/)

https://metacpan.org/pod/DateTime::Format::Oracle
https://metacpan.org/pod/DateTime::Format::Pg

Has method 'format_timestamp_with_time_zone' so we should rename