### PR TITLE
Set formatter class to display correct data while viewing value

### DIFF
--- a/lib/DBIx/Class/InflateColumn/DateTime.pm
+++ b/lib/DBIx/Class/InflateColumn/DateTime.pm
@@ -246,6 +246,12 @@ sub _post_inflate_datetime {
 
   $dt->set_time_zone($info->{timezone}) if defined $info->{timezone};
   $dt->set_locale($info->{locale}) if defined $info->{locale};
+  my $f =  defined $info->{formatter}  &&  $info->{formatter}
+    || $ENV{DBIC_AUTOSET_DATETIME_FORMATTER} && 'auto';
+  if( $f ) {
+    $f =  $f eq 'auto' ? $self->_datetime_parser : $f;
+    $dt->set_formatter( $f );
+  }
 
   return $dt;
 }

--- a/lib/DBIx/Class/InflateColumn/DateTime.pm
+++ b/lib/DBIx/Class/InflateColumn/DateTime.pm
@@ -36,6 +36,26 @@ If you want to set a specific timezone and locale for that field, use:
     starts_when => { data_type => 'datetime', timezone => "America/Chicago", locale => "de_DE" }
   );
 
+If you want to set a specific formatter to use when print value of the inflated
+DateTime object to user:
+
+  __PACKAGE__->add_columns(
+    starts_when => { data_type => 'datetime', formatter => DateTime::Format::Pg->new() }
+  );
+
+If you want the inflated DateTime object to have the detected formatter based on
+DBIx::Class::Storage::DBI::* you are using, set it to 'auto':
+
+  __PACKAGE__->add_columns(
+    starts_when => { data_type => 'datetime', formatter => 'auto' }
+  );
+
+If you want all inflated DateTime objects to have the detected formatter set
+DBIC_AUTOSET_DATETIME_FORMATTER to 1.
+
+Please note: this affect only the formatter how DateTime will be formatter to a user.
+This does nothing how a value is formatted for a database.
+
 If you want to inflate no matter what data_type your column is,
 use inflate_datetime or inflate_date:
 

--- a/t/inflate/datetime_pg.t
+++ b/t/inflate/datetime_pg.t
@@ -20,12 +20,18 @@ my $dt = DateTime->new( year => 2000, time_zone => "America/Chicago" );
 
 warnings_are {
   my $event = $schema->resultset("EventTZPg")->find(1);
+
   $event->update({created_on => '2009-01-15 17:00:00+00'});
   $event->discard_changes;
   isa_ok($event->created_on, "DateTime") or diag $event->created_on;
   is($event->created_on->time_zone->name, "America/Chicago", "Timezone changed");
+
   # Time zone difference -> -6hours
   is($event->created_on->iso8601, "2009-01-15T11:00:00", "Time with TZ correct");
+
+  # Test behavior when DateTime has or has not fomatter
+  is($event->created_on, "2009-01-15T11:00:00",      'Default DateTime does not display timezones');
+  is($event->starts_at,  "2006-04-25 22:24:33-0500", 'Inflated DateTime has initialized formatter');
 
 # test 'timestamp without time zone'
   my $dt = DateTime->from_epoch(epoch => time);

--- a/t/lib/DBICTest/Schema/EventTZPg.pm
+++ b/t/lib/DBICTest/Schema/EventTZPg.pm
@@ -11,8 +11,13 @@ __PACKAGE__->table('event');
 
 __PACKAGE__->add_columns(
   id => { data_type => 'integer', is_auto_increment => 1 },
-  starts_at => { data_type => 'datetime', timezone => "America/Chicago", locale => 'de_DE' },
-  created_on => { data_type => 'timestamp with time zone', timezone => "America/Chicago" },
+  starts_at => {
+    data_type => 'datetime',
+    timezone  => "America/Chicago",
+    locale    => 'de_DE',
+    formatter => 'auto',  # This does not affect formatter used to store values into database
+  },
+  created_on    => { data_type => 'timestamp with time zone', timezone => "America/Chicago" },
   ts_without_tz => { data_type => 'timestamp without time zone' },
 );
 


### PR DESCRIPTION
FIXES: [RT133621](https://rt-cpan.github.io/Public/Bug/Display/133621/) https://rt.cpan.org/Ticket/Display.html?id=133621

When inflated value is stringified it does not display all info about the date. Eg. `$result->date_field .""` will be formatted as `2009-01-15T11:00:00` instead of the expected `2009-01-15 11:00:00+0300` if `DBD::Pg` was used.

In this pull request we implement the option to setup the formatter or autosetup it to be the same as underlied database.


