### PR TITLE
Make t/53lean_startup.t robust wrt stacktrace details

### DIFF
--- a/t/53lean_startup.t
+++ b/t/53lean_startup.t
@@ -30,7 +30,7 @@ BEGIN {
         # exclude our test suite, known "module require-rs" and eval frames
         $caller[1] =~ /^ t [\/\\] /x
           or
-        $caller[0] =~ /^ (?: base | parent | Class::C3::Componentised | Module::Inspector | Module::Runtime ) $/x
+        $caller[0] =~ /^ (?: base | parent | Class::C3::Componentised | Module::Inspector | Module::Runtime ) $/x && $caller[3] !~ m/::BEGIN$/
           or
         $caller[3] eq '(eval)',
       )


### PR DESCRIPTION
This test checks if none of DBIC is loading anything unexpected. It
contains logic to skip over indirect loaders such as base, parent and
Class::C3::Componentised. However, this erroneously skips over direct
dependencies of such classes. In particular, it assigns the MRO::Compat
dependency in Class::C3::Componentised to whatever class it thinks it
loads CCC. Before ad89278 this worked out fine, because it would be
assigned to main, which while meaningless isn't part of DBIx::Class so
ignored. After ad89278, it's assigned to the class that loads CCC, which
is DBIx::Class::Componentised, which is part of DBIC, and hence fails
the test.

This test will cause it to not skip on for any BEGIN blocks inside an
indirect loader, therefor the MRO::Compat dependency will correctly be
assigned to Class::C3::Componentised.