### PR TITLE
Adding GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI native
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,97 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+#  schedule:
+#    - cron: '42 5 * * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest]
+        #runner: [ubuntu-latest, macos-latest, windows-latest]
+        perl: [ '5.36' ]
+        exclude:
+          - runner: windows-latest
+            perl: '5.36'
+
+    runs-on: ${{matrix.runner}}
+    name: OS ${{matrix.runner}} Perl ${{matrix.perl}}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up perl
+      uses: shogo82148/actions-setup-perl@v1
+      with:
+          perl-version: ${{ matrix.perl }}
+          distribution: ${{ ( matrix.runner == 'windows-latest' && 'strawberry' ) || 'default' }}
+
+    - name: Show Perl Version
+      run: |
+        perl -v
+
+    - name: Install Modules
+      run: |
+        cpanm -v
+        cpanm --notest Module::Install
+        cpanm --installdeps --notest .
+
+        cpanm --notest Class::DBI::Plugin::DeepAbstractSearch
+        cpanm --notest Class::MethodCache
+        cpanm --notest Class::Unload
+        cpanm --notest Date::Simple
+        cpanm --notest DateTime::Format::MySQL
+        cpanm --notest DateTime::Format::Pg
+        cpanm --notest DateTime::Format::SQLite
+        cpanm --notest DateTime::Format::Strptime
+        cpanm --notest JSON
+        cpanm --notest JSON::Any
+        cpanm --notest JSON::DWIW
+        cpanm --notest JSON::XS
+        cpanm --notest Math::Base36
+        cpanm --notest MooseX::Types::JSON
+        cpanm --notest MooseX::Types::LoadableClass
+        cpanm --notest MooseX::Types::Path::Class
+        cpanm --notest PadWalker
+        cpanm --notest Pod::Coverage
+        cpanm --notest SQL::Translator
+        cpanm --notest Test::EOL
+        cpanm --notest Test::NoTabs
+        cpanm --notest Test::Pod
+        cpanm --notest Test::Pod::Coverage
+        cpanm --notest Test::Strict
+        cpanm --notest Text::CSV
+        cpanm --notest Time::Piece::MySQL
+
+    - name: Show Errors on Windows
+      if:  ${{ failure() && matrix.runner == 'windows-latest' }}
+      run: |
+         ls -l C:/Users/
+         ls -l C:/Users/RUNNER~1/
+         cat C:/Users/runneradmin/.cpanm/work/*/build.log
+
+    - name: Show Errors on Ubuntu
+      if:  ${{ failure() && startsWith( matrix.runner, 'ubuntu-')}}
+      run: |
+         cat /home/runner/.cpanm/work/*/build.log
+
+    - name: Show Errors on OSX
+      if:  ${{ failure() && startsWith( matrix.runner, 'macos-')}}
+      run: |
+         cat  /Users/runner/.cpanm/work/*/build.log
+
+    - name: Run tests
+      env:
+        AUTHOR_TESTING: 1
+        RELEASE_TESTING: 1
+      run: |
+        perl Makefile.PL
+        make
+        make test
+
+

--- a/.github/workflows/with_pg.yaml
+++ b/.github/workflows/with_pg.yaml
@@ -39,10 +39,6 @@ jobs:
         perl -v
 
     - name: Install Modules
-      env:
-        DBICTEST_PG_DSN='dbi:Pg:database=dbic_test;host=postgres_service'
-        DBICTEST_PG_USER='dbic_user'
-        DBICTEST_PG_PASS='secret'
       run: |
         cpanm -v
         cpanm --notest Module::Install
@@ -88,6 +84,9 @@ jobs:
       env:
         AUTHOR_TESTING: 1
         RELEASE_TESTING: 1
+        DBICTEST_PG_DSN: 'dbi:Pg:database=dbic_test;host=postgres_service'
+        DBICTEST_PG_USER: 'dbic_user'
+        DBICTEST_PG_PASS: 'secret'
       run: |
         perl Makefile.PL
         make

--- a/.github/workflows/with_pg.yaml
+++ b/.github/workflows/with_pg.yaml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         perl: [ '5.36' ]
+        postgres: [ 'latest' ]
 
     services:
       postgres_service:

--- a/.github/workflows/with_pg.yaml
+++ b/.github/workflows/with_pg.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: CI in Docker container
 
 on:
   push:
@@ -14,6 +14,20 @@ jobs:
       matrix:
         perl: [ '5.36' ]
 
+    services:
+      postgres_service:
+        image: postgres:${{matrix.postgres}}
+        env:
+          POSTGRES_USER: dbic_user
+          POSTGRES_PASSWORD: secret
+          POSTGRES_DB: dbic_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+
     runs-on: ubuntu-latest
     container: perl:${{ matrix.perl }}
 
@@ -25,6 +39,10 @@ jobs:
         perl -v
 
     - name: Install Modules
+      env:
+        DBICTEST_PG_DSN='dbi:Pg:database=dbic_test;host=postgres_service'
+        DBICTEST_PG_USER='dbic_user'
+        DBICTEST_PG_PASS='secret'
       run: |
         cpanm -v
         cpanm --notest Module::Install
@@ -56,6 +74,10 @@ jobs:
         cpanm --notest Test::Strict
         cpanm --notest Text::CSV
         cpanm --notest Time::Piece::MySQL
+
+        apt-get install libpq-dev
+
+        cpanm --notest DBD::Pg
 
     - name: Show Errors on Ubuntu
       if:  ${{ failure() && startsWith( matrix.runner, 'ubuntu-')}}

--- a/.github/workflows/with_pg.yaml
+++ b/.github/workflows/with_pg.yaml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+#  schedule:
+#    - cron: '42 5 * * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        perl: [ '5.36' ]
+
+    runs-on: ubuntu-latest
+    container: perl:${{ matrix.perl }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Show Perl Version
+      run: |
+        perl -v
+
+    - name: Install Modules
+      run: |
+        cpanm -v
+        cpanm --notest Module::Install
+        cpanm --installdeps --notest .
+
+        cpanm --notest Class::DBI::Plugin::DeepAbstractSearch
+        cpanm --notest Class::MethodCache
+        cpanm --notest Class::Unload
+        cpanm --notest Date::Simple
+        cpanm --notest DateTime::Format::MySQL
+        cpanm --notest DateTime::Format::Pg
+        cpanm --notest DateTime::Format::SQLite
+        cpanm --notest DateTime::Format::Strptime
+        cpanm --notest JSON
+        cpanm --notest JSON::Any
+        cpanm --notest JSON::DWIW
+        cpanm --notest JSON::XS
+        cpanm --notest Math::Base36
+        cpanm --notest MooseX::Types::JSON
+        cpanm --notest MooseX::Types::LoadableClass
+        cpanm --notest MooseX::Types::Path::Class
+        cpanm --notest PadWalker
+        cpanm --notest Pod::Coverage
+        cpanm --notest SQL::Translator
+        cpanm --notest Test::EOL
+        cpanm --notest Test::NoTabs
+        cpanm --notest Test::Pod
+        cpanm --notest Test::Pod::Coverage
+        cpanm --notest Test::Strict
+        cpanm --notest Text::CSV
+        cpanm --notest Time::Piece::MySQL
+
+    - name: Show Errors on Ubuntu
+      if:  ${{ failure() && startsWith( matrix.runner, 'ubuntu-')}}
+      run: |
+         cat /home/runner/.cpanm/work/*/build.log
+
+    - name: Run tests
+      env:
+        AUTHOR_TESTING: 1
+        RELEASE_TESTING: 1
+      run: |
+        perl Makefile.PL
+        make
+        make test
+

--- a/.github/workflows/with_pg.yaml
+++ b/.github/workflows/with_pg.yaml
@@ -81,6 +81,21 @@ jobs:
       run: |
          cat /home/runner/.cpanm/work/*/build.log
 
+    - name: Run make
+      run: |
+        perl Makefile.PL
+        make
+
+    - name: Run tests with prove
+      env:
+        AUTHOR_TESTING: 1
+        RELEASE_TESTING: 1
+        DBICTEST_PG_DSN: 'dbi:Pg:database=dbic_test;host=postgres_service'
+        DBICTEST_PG_USER: 'dbic_user'
+        DBICTEST_PG_PASS: 'secret'
+      run: |
+        prove -lv t/50fork.t
+
     - name: Run tests
       env:
         AUTHOR_TESTING: 1
@@ -89,7 +104,5 @@ jobs:
         DBICTEST_PG_USER: 'dbic_user'
         DBICTEST_PG_PASS: 'secret'
       run: |
-        perl Makefile.PL
-        make
         make test
 


### PR DESCRIPTION
An initial version of using GitHub Actions as a CI.
In one file we run perl natively and without a database, in the other file we use a PostgreSQL database to test with.